### PR TITLE
CH-351: User data store implementation

### DIFF
--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -54,6 +54,9 @@ class AlertStore(DocumentDataStore):
     def get_data(self, **kwargs):
         """Fetch data from store.
 
+        Keyword Args:
+            queryparams (json/bson): JSON / BSON string.
+
         Returns:
             list: List of records.
         """
@@ -64,6 +67,7 @@ class AlertStore(DocumentDataStore):
 
         Args:
             data (json/bson): JSON / BSON document to save to the data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             JSON: {status: "", matched_count: "", insert_id: ""}
@@ -75,6 +79,7 @@ class AlertStore(DocumentDataStore):
 
         Args:
             data (json/bson): JSON / BSON string.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             deleted count: 1 (Success) or 0 (Failure)
@@ -95,7 +100,7 @@ class UserMgmtStore(DocumentDataStore):
     def get_data(self, **kwargs):
         """Fetch data from store.
 
-        Kwargs:
+        Keyword Args:
             queryparams (json/bson): JSON / BSON string.
 
         Returns:
@@ -108,6 +113,7 @@ class UserMgmtStore(DocumentDataStore):
 
         Args:
             data (json/bson): JSON / BSON document to save to the data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             JSON: {status: "", matched_count: "", insert_id: ""}
@@ -119,6 +125,7 @@ class UserMgmtStore(DocumentDataStore):
 
         Args:
             data (json/bson): JSON / BSON string.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             deleted count: 1 (Success) or 0 (Failure)

--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -36,6 +36,10 @@ class DocumentDataStore(ABC):
     def store_data(self, data, **kwargs):
         pass
 
+    @abstractmethod
+    def delete_data(self, data, **kwargs):
+        pass
+
 
 class AlertStore(DocumentDataStore):
 
@@ -65,3 +69,55 @@ class AlertStore(DocumentDataStore):
             JSON: {status: "", matched_count: "", insert_id: ""}
         """
         return self._dsb.save_data(self._data_store_name, data, **kwargs)
+
+    def delete_data(self, data, **kwargs):
+        """Delete data from store.
+
+        Args:
+            data (json/bson): JSON / BSON string.
+
+        Returns:
+            deleted count: 1 (Success) or 0 (Failure)
+        """
+        return self._dsb.delete_data(self._data_store_name, data, **kwargs)
+
+
+class UserMgmtStore(DocumentDataStore):
+
+    def __init__(self, server_endpoint, db_name, data_store_name) -> None:
+        super().__init__(server_endpoint, db_name)
+        self._data_store_name = data_store_name
+        # TODO: Read the db type from config file.
+        self._dsb = DBManager.get_db_instance(
+            db_type=DBTypes.MONGODB.value,
+            db_endpoint=self._server_endpoint, db_name=self._db_name)
+
+    def get_data(self, **kwargs):
+        """Fetch data from store.
+
+        Returns:
+            list: List of records.
+        """
+        return self._dsb.get_data(self._data_store_name, **kwargs)
+
+    def store_data(self, data, **kwargs):
+        """Save data to store.
+
+        Args:
+            data (json/bson): JSON / BSON document to save to the data store.
+
+        Returns:
+            JSON: {status: "", matched_count: "", insert_id: ""}
+        """
+        return self._dsb.save_data(self._data_store_name, data, **kwargs)
+
+    def delete_data(self, data, **kwargs):
+        """Delete data from store.
+
+        Args:
+            data (json/bson): JSON / BSON string.
+
+        Returns:
+            deleted count: 1 (Success) or 0 (Failure)
+        """
+        return self._dsb.delete_data(self._data_store_name, data, **kwargs)

--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -101,7 +101,7 @@ class UserMgmtStore(DocumentDataStore):
         """Fetch data from store.
 
         Keyword Args:
-            queryparams (json/bson): JSON / BSON string.
+            **kwargs: queryparams (json/bson): JSON / BSON string.
 
         Returns:
             list: List of records.

--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -55,7 +55,7 @@ class AlertStore(DocumentDataStore):
         """Fetch data from store.
 
         Keyword Args:
-            queryparams (json/bson): JSON / BSON string.
+            **kwargs: queryparams (json/bson): JSON / BSON string.
 
         Returns:
             list: List of records.

--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -95,6 +95,9 @@ class UserMgmtStore(DocumentDataStore):
     def get_data(self, **kwargs):
         """Fetch data from store.
 
+        Kwargs:
+            queryparams (json/bson): JSON / BSON string.
+
         Returns:
             list: List of records.
         """

--- a/common/db_store/admin_db.py
+++ b/common/db_store/admin_db.py
@@ -106,6 +106,7 @@ class MongoDBAdmin(DBAdmin):
         Args:
             data_store_name (str): Name of data store.
             index_key (str): Key/field on which index is created.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Unable to create index.
@@ -121,6 +122,7 @@ class MongoDBAdmin(DBAdmin):
 
         Args:
             data_store_name (str): Name of data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Returns:
             list: List of indexes.
@@ -137,6 +139,7 @@ class MongoDBAdmin(DBAdmin):
         Args:
             data_store_name (str): Name of data store.
             index_name (str): Index name.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Unable to drop index.
@@ -158,7 +161,7 @@ class MongoDBAdmin(DBAdmin):
         Args:
             data_store (str): Type of data store.
             data_store_name (str): Name of data store.
-            kwargs (_type_): keyword arguments.
+            **kwargs: Arbitrary keyword arguments.
         """
         if data_store_type == DATASTORE.TIMESERIES.value:
             timeField = kwargs.get('timeField')
@@ -191,6 +194,7 @@ class MongoDBAdmin(DBAdmin):
         Args:
             data_store_name (str): Name of data store.
             data_store_type (str): Type of data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Invalid data store.

--- a/common/db_store/db.py
+++ b/common/db_store/db.py
@@ -90,6 +90,7 @@ class MongoDB(DB):
 
         Args:
             data_store_name (str): Name of data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Unable to fetch data.
@@ -116,6 +117,7 @@ class MongoDB(DB):
         Args:
             data_store_name (str): Name of data store.
             data (json/bson): JSON / BSON document to save to the data store.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Unable to save data.
@@ -146,6 +148,7 @@ class MongoDB(DB):
         Args:
             data_store_name (str): Name of data store.
             data (json/bson): JSON / BSON string.
+            **kwargs: Arbitrary keyword arguments.
 
         Raises:
             DBError: Failed to delete data.

--- a/common/db_store/db.py
+++ b/common/db_store/db.py
@@ -90,7 +90,7 @@ class MongoDB(DB):
 
         Args:
             data_store_name (str): Name of data store.
-            **kwargs: Arbitrary keyword arguments.
+            **kwargs: queryparams (json/bson): JSON / BSON string.
 
         Raises:
             DBError: Unable to fetch data.

--- a/common/db_store/db.py
+++ b/common/db_store/db.py
@@ -45,6 +45,10 @@ class DB(ABC):
     def save_data(self, data_store_name, data, **kwargs):
         pass
 
+    @abstractmethod
+    def delete_data(self, data_store_name, data, **kwargs):
+        pass
+
 
 class STATUSES(Enum):
     SUCCESS = "success"
@@ -135,6 +139,26 @@ class MongoDB(DB):
         except Exception as e:
             # Log.error(f"Unable to fetch data from data store. Error {e}")
             raise DBError(f"Unable to save data to data store. Error {e}")
+
+    def delete_data(self, data_store_name: str, data, **kwargs):
+        """Delete data from the data store.
+
+        Args:
+            data_store_name (str): Name of data store.
+            data (json/bson): JSON / BSON string.
+
+        Raises:
+            DBError: Failed to delete data.
+
+        Returns:
+            deleted count: 1 (Success) or 0 (Failure)
+        """
+        try:
+            result = self._db[data_store_name].delete_one(data)
+            return result.deleted_count
+        except Exception as e:
+            # Log.error(f"Failed to Delete data from data store. Error {e}")
+            raise DBError(f"Failed to Delete data from data store. Error {e}")
 
     def close(self):
         """End all server sessions created by current client \

--- a/common/test/test_alert_data_store.py
+++ b/common/test/test_alert_data_store.py
@@ -25,6 +25,7 @@ from common.db_store.db_manager import DBManager
 
 pytestmark = pytest.mark.unit
 data_store = None
+admin_db = None
 
 
 @pytest.fixture

--- a/common/test/test_datastore_backend.py
+++ b/common/test/test_datastore_backend.py
@@ -19,8 +19,7 @@
 
 import pytest
 from datetime import datetime
-from common.db_store.db import MongoDB
-from common.db_store.admin_db import MongoDBAdmin
+from common.db_store.db_manager import DBManager
 
 
 pytestmark = pytest.mark.unit
@@ -31,21 +30,19 @@ db = None
 @pytest.fixture
 def setup_admin_db():
     global admin_db
-    admin_db = MongoDBAdmin(
+    admin_db = DBManager.get_admin_db_instance(
+       admin_db_type='mongodb_admin',
        db_endpoint="mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo:27017",
        db_name="test")
-    yield
-    admin_db.close_connection()
 
 
 @pytest.fixture
 def setup_db():
     global db
-    db = MongoDB(
+    db = DBManager.get_db_instance(
+       db_type='mongodb',
        db_endpoint="mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo:27017",
        db_name="test")
-    yield
-    db.close()
 
 
 def test_create_time_series_data_store(setup_admin_db):

--- a/common/test/test_user_data_store.py
+++ b/common/test/test_user_data_store.py
@@ -17,9 +17,9 @@
 # For any questions about this software or licensing, please email
 # opensource@seagate.com or cortx-questions@seagate.com.
 
+import uuid
 import pytest
-from datetime import datetime
-from common.data_stores.data_store import AlertStore
+from common.data_stores.data_store import UserMgmtStore
 from common.db_store.db_manager import DBManager
 
 
@@ -30,9 +30,9 @@ data_store = None
 @pytest.fixture
 def setup_datastore():
     global data_store
-    data_store = AlertStore(
+    data_store = UserMgmtStore(
         'mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo:27017',
-        db_name='test', data_store_name='alert')
+        db_name='test', data_store_name='user_mgmt')
 
 
 @pytest.fixture
@@ -46,31 +46,39 @@ def setup_admin_db():
 
 def test_save_data(setup_datastore):
     """Test by saving data and reading it back."""
-    record = {"timestamp": datetime.now(),
-              "comp": "disk", "measures": {'cpu': '23', 'memory': '235'}}
+    record = {
+        "user_id": str(uuid.uuid4().hex),
+        "username": "admin",
+        "password": "admin",
+        "email": "admin@gmail.com",
+        "user_type": "manager"
+    }
     result = data_store.store_data(data=record)
     assert result is not None, "Failed to save Data."
+
     get_list_of_records = data_store.get_data()
-    assert any(r['measures'] == record['measures']
+    assert any(r['username'] == record['username']
                for r in get_list_of_records)
 
 
 def test_get_data(setup_datastore):
     """Test by listing data."""
     get_list_of_records = data_store.get_data()
+    print(get_list_of_records)
     assert get_list_of_records is not None, "Failed to fetch Data."
 
 
 def test_delete_data(setup_datastore):
     """Test by deleting data."""
     record = {
-        "comp": "disk"
+        "username": "admin"
     }
     result = data_store.delete_data(data=record)
+    print(result)
     assert result, "Failed to Delete Data."
 
 
 # Clean Up.
 def test_delete_collection(setup_admin_db):
     """Delete collection."""
-    admin_db.delete_data_store("alert")
+    admin_db.delete_data_store("user_mgmt")

--- a/common/test/test_user_data_store.py
+++ b/common/test/test_user_data_store.py
@@ -25,6 +25,7 @@ from common.db_store.db_manager import DBManager
 
 pytestmark = pytest.mark.unit
 data_store = None
+admin_db = None
 
 
 @pytest.fixture
@@ -64,7 +65,6 @@ def test_save_data(setup_datastore):
 def test_get_data(setup_datastore):
     """Test by listing data."""
     get_list_of_records = data_store.get_data()
-    print(get_list_of_records)
     assert get_list_of_records is not None, "Failed to fetch Data."
 
 
@@ -74,7 +74,6 @@ def test_delete_data(setup_datastore):
         "username": "admin"
     }
     result = data_store.delete_data(data=record)
-    print(result)
     assert result, "Failed to Delete Data."
 
 


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
- https://jts.seagate.com/browse/CH-351

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

# Testing
Unit test Results : 
```
[root@cortx-ha-headless-svc cortx-halo]# python3 test/py/main.py -m 'unit'
==================================================== test session starts ====================================================
platform linux -- Python 3.6.8, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /cortx-halo, configfile: pytest.ini
collected 26 items / 12 deselected / 14 selected

common/test/test_alert_data_store.py::test_save_data PASSED                                                           [  7%]
common/test/test_alert_data_store.py::test_get_data PASSED                                                            [ 14%]
common/test/test_alert_data_store.py::test_delete_data PASSED                                                         [ 21%]
common/test/test_alert_data_store.py::test_delete_collection PASSED                                                   [ 28%]
common/test/test_datastore_backend.py::test_create_time_series_data_store PASSED                                      [ 35%]
common/test/test_datastore_backend.py::test_create_index PASSED                                                       [ 42%]
common/test/test_datastore_backend.py::test_save_data PASSED                                                          [ 50%]
common/test/test_datastore_backend.py::test_get_data PASSED                                                           [ 57%]
common/test/test_datastore_backend.py::test_delete_index PASSED                                                       [ 64%]
common/test/test_datastore_backend.py::test_delete_collection PASSED                                                  [ 71%]
common/test/test_user_data_store.py::test_save_data PASSED                                                            [ 78%]
common/test/test_user_data_store.py::test_get_data PASSED                                                             [ 85%]
common/test/test_user_data_store.py::test_delete_data PASSED                                                          [ 92%]
common/test/test_user_data_store.py::test_delete_collection PASSED                                                    [100%]

============================================= 14 passed, 12 deselected in 1.31s =============================================
```