### PR TITLE
CH-352: Added support for skip, sort, limit and filter.

### DIFF
--- a/common/data_stores/data_store.py
+++ b/common/data_stores/data_store.py
@@ -58,7 +58,7 @@ class AlertStore(DocumentDataStore):
             **kwargs: queryparams (json/bson): JSON / BSON string.
 
         Returns:
-            list: List of records.
+            tuple: (List of records, Total count of documents)
         """
         return self._dsb.get_data(self._data_store_name, **kwargs)
 
@@ -104,7 +104,7 @@ class UserMgmtStore(DocumentDataStore):
             **kwargs: queryparams (json/bson): JSON / BSON string.
 
         Returns:
-            list: List of records.
+            tuple: (List of records, Total count of documents)
         """
         return self._dsb.get_data(self._data_store_name, **kwargs)
 

--- a/common/db_store/db.py
+++ b/common/db_store/db.py
@@ -95,11 +95,12 @@ class MongoDB(DB):
             **kwargs: Arbitrary keyword arguments.
             queryparams (dict): dict following pymongo convention.
             sort_query (List of tuples): (field_to_sort, sort_direction)
-                direction can be ASC/ASCENDING or DSC/DESCENDING.
-            limit (int): Limit for no. of documents returned by query.
-            skip (int): To skip the first x records of the returned results.
+                direction can be ASC/ASCENDING or DESC/DESCENDING.
             count(bool): True / False. To get the total count of documents
                 irrespective of limit & skip field.
+            skip (int): To skip the first x records of the returned results.
+            limit (int): Limit for no. of documents returned by query.
+                Ex. To get the docs from 11 to 20 set skip=10 & limit=20.
 
         Raises:
             DBError: Unable to fetch data.
@@ -121,11 +122,11 @@ class MongoDB(DB):
                 for sort_field, sort_dir in sort_query:
                     if sort_dir.upper() in ('ASC', 'ASCENDING'):
                         sort_fields.append((sort_field, pymongo.ASCENDING))
-                    elif sort_dir.upper() in ('DSC', 'DESCENDING'):
+                    elif sort_dir.upper() in ('DESC', 'DESCENDING'):
                         sort_fields.append((sort_field, pymongo.DESCENDING))
                     else:
                         raise ValueError("Invalid direction for sort.\
-                            Use 'ASC'/'ASCENDING' or 'DSC'/'DESCENDING'.")
+                            Use 'ASC'/'ASCENDING' or 'DESC'/'DESCENDING'.")
             else:
                 sort_fields = None
 

--- a/common/db_store/db.py
+++ b/common/db_store/db.py
@@ -90,26 +90,66 @@ class MongoDB(DB):
 
         Args:
             data_store_name (str): Name of data store.
-            **kwargs: queryparams (json/bson): JSON / BSON string.
+
+        Keyword Args:
+            **kwargs: Arbitrary keyword arguments.
+            queryparams (dict): dict following pymongo convention.
+            sort_query (List of tuples): (field_to_sort, sort_direction)
+                direction can be ASC/ASCENDING or DSC/DESCENDING.
+            limit (int): Limit for no. of documents returned by query.
+            skip (int): To skip the first x records of the returned results.
+            count(bool): True / False. To get the total count of documents
+                irrespective of limit & skip field.
 
         Raises:
             DBError: Unable to fetch data.
 
         Returns:
-            list: List of records.
+            tuple: (List of records, Total count of documents)
         """
         result_list = []
-        query_params = kwargs.get('queryparams')
+        total_count = None
+        query_filter = kwargs.get('queryparams')
+        sort_query = kwargs.get('sort_query')
+        limit = kwargs.get('limit') if kwargs.get('limit') else 0
+        skip = kwargs.get('skip') if kwargs.get('skip') else 0
+        count = kwargs.get('count')
 
         try:
-            results = self._db[data_store_name].find(query_params)
+            if sort_query is not None:
+                sort_fields = []
+                for sort_field, sort_dir in sort_query:
+                    if sort_dir.upper() in ('ASC', 'ASCENDING'):
+                        sort_fields.append((sort_field, pymongo.ASCENDING))
+                    elif sort_dir.upper() in ('DSC', 'DESCENDING'):
+                        sort_fields.append((sort_field, pymongo.DESCENDING))
+                    else:
+                        raise ValueError("Invalid direction for sort.\
+                            Use 'ASC'/'ASCENDING' or 'DSC'/'DESCENDING'.")
+            else:
+                sort_fields = None
+
+            # As per pymongo convention pass empty dict as filter
+            # if query_filter is None.
+            if query_filter is None:
+                query_filter = {}
+
+            results = self._db[data_store_name].find(
+                filter=query_filter,
+                sort=sort_fields,
+                skip=skip, limit=limit)
+
+            if count:
+                total_count = self._db[data_store_name].count_documents(
+                    query_filter)
+
             for result in results:
                 result_list.append(result)
         except Exception as e:
             # Log.error(f"Unable to fetch data from data store. Error {e}")
             raise DBError(f"Unable to fetch data from data store. Error {e}")
 
-        return result_list
+        return result_list, total_count
 
     def save_data(self, data_store_name: str, data, **kwargs):
         """Save data to the data store.

--- a/common/test/test_alert_data_store.py
+++ b/common/test/test_alert_data_store.py
@@ -51,14 +51,14 @@ def test_save_data(setup_datastore):
               "comp": "disk", "measures": {'cpu': '23', 'memory': '235'}}
     result = data_store.store_data(data=record)
     assert result is not None, "Failed to save Data."
-    get_list_of_records = data_store.get_data()
+    get_list_of_records, _ = data_store.get_data()
     assert any(r['measures'] == record['measures']
                for r in get_list_of_records)
 
 
 def test_get_data(setup_datastore):
     """Test by listing data."""
-    get_list_of_records = data_store.get_data()
+    get_list_of_records, _ = data_store.get_data()
     assert get_list_of_records is not None, "Failed to fetch Data."
 
 

--- a/common/test/test_datastore_backend.py
+++ b/common/test/test_datastore_backend.py
@@ -70,14 +70,14 @@ def test_save_data(setup_db):
               "comp": "disk", "measures": {'cpu': '23', 'memory': '235'}}
     result = db.save_data("test_coll", data=record)
     assert result is not None, "Failed to save Data."
-    get_list_of_records = db.get_data("test_coll")
+    get_list_of_records, _ = db.get_data("test_coll")
     assert any(r['measures'] == record['measures']
                for r in get_list_of_records)
 
 
 def test_get_data(setup_db):
     """Test by listing data."""
-    get_list_of_records = db.get_data("test_coll")
+    get_list_of_records, _ = db.get_data("test_coll")
     assert get_list_of_records is not None, "Failed to fetch Data."
 
 

--- a/common/test/test_user_data_store.py
+++ b/common/test/test_user_data_store.py
@@ -57,14 +57,14 @@ def test_save_data(setup_datastore):
     result = data_store.store_data(data=record)
     assert result is not None, "Failed to save Data."
 
-    get_list_of_records = data_store.get_data()
+    get_list_of_records, _ = data_store.get_data()
     assert any(r['username'] == record['username']
                for r in get_list_of_records)
 
 
 def test_get_data(setup_datastore):
     """Test by listing data."""
-    get_list_of_records = data_store.get_data()
+    get_list_of_records, _ = data_store.get_data(count=True)
     assert get_list_of_records is not None, "Failed to fetch Data."
 
 


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
- [CH-352](https://jts.seagate.com/browse/CH-352)
Alert data store adding support of advance options

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added - Full test details - https://jts.seagate.com/secure/attachment/533495/CH-352.txt
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide  https://seagate-systems.atlassian.net/wiki/spaces/CH/pages/1074757633/LLD+Event+workflow+and+management+backend#Data-Store-Backend-(DSB)

# Unit test results
Note : One provisioner test failed which is not related to this PR.
```
[root@cortx-ha-headless-svc cortx-halo]# python3 test/py/main.py -m 'unit'
==================================================== test session starts ====================================================
platform linux -- Python 3.6.8, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /cortx-halo, configfile: pytest.ini
collected 27 items / 12 deselected / 15 selected

common/test/test_alert_data_store.py::test_save_data PASSED                                                           [  6%]
common/test/test_alert_data_store.py::test_get_data PASSED                                                            [ 13%]
common/test/test_alert_data_store.py::test_delete_data PASSED                                                         [ 20%]
common/test/test_alert_data_store.py::test_delete_collection PASSED                                                   [ 26%]
common/test/test_datastore_backend.py::test_create_time_series_data_store PASSED                                      [ 33%]
common/test/test_datastore_backend.py::test_create_index PASSED                                                       [ 40%]
common/test/test_datastore_backend.py::test_save_data PASSED                                                          [ 46%]
common/test/test_datastore_backend.py::test_get_data PASSED                                                           [ 53%]
common/test/test_datastore_backend.py::test_delete_index PASSED                                                       [ 60%]
common/test/test_datastore_backend.py::test_delete_collection PASSED                                                  [ 66%]
common/test/test_user_data_store.py::test_save_data PASSED                                                            [ 73%]
common/test/test_user_data_store.py::test_get_data PASSED                                                             [ 80%]
common/test/test_user_data_store.py::test_delete_data PASSED                                                          [ 86%]
common/test/test_user_data_store.py::test_delete_collection PASSED                                                    [ 93%]
provisioner/test/unit/test_network_config.py::test_network_config FAILED                                              [100%]

========================================================= FAILURES ==========================================================
____________________________________________________ test_network_config ____________________________________________________

    def test_network_config():
        config(cfgfile='test_network_config_input.yaml')
>       with open("test_network_config_output.yaml", "r") as f:
E       FileNotFoundError: [Errno 2] No such file or directory: 'test_network_config_output.yaml'

provisioner/test/unit/test_network_config.py:34: FileNotFoundError
--------------------------------------------------- Captured stdout call ----------------------------------------------------
[Errno 2] No such file or directory: '/cortx-halo/provisioner/components/network/test_network_config_input.yaml'
================================================== short test summary info ==================================================
FAILED provisioner/test/unit/test_network_config.py::test_network_config - FileNotFoundError: [Errno 2] No such file or di...
======================================== 1 failed, 14 passed, 12 deselected in 3.84s ========================================
[root@cortx-ha-headless-svc cortx-halo]#
```